### PR TITLE
Several smaller bugfixes

### DIFF
--- a/GA_Detect.py
+++ b/GA_Detect.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import multiprocessing as mp
 from OS_Airports import VABB
 import OS_Funcs as OSF
+import os
 import glob
 
 
@@ -39,6 +40,8 @@ def main(start_n, fidder, do_write):
     odir_da_ga = top_dir + 'OUT_DATA/PSGA/'
 
     odirs = [odir_pl_nm, odir_pl_ga, odir_da_nm, odir_da_ga]
+    for odir in odirs:
+        os.makedirs(odir, exist_ok=True)
 
     # Output filenames for saving data about go-arounds
     out_file_ga = 'GA_MET_NEW.csv'
@@ -60,12 +63,12 @@ def main(start_n, fidder, do_write):
                       Temp, Dewp, Wind_Spd, Wind_Gust, Wind_Dir,Cld_Base,\
                       CB, Vis, Pressure\n')
     files = []
-    files = glob.glob(indir+'**.pkl')
+    files = glob.glob(indir+'*.pkl') + glob.glob(indir+'*/*.pkl')
     files.sort()
 
     fli_len = len(files)
 
-    colormap = {'GND': 'black', 'CL': 'green', 'CR': 'blue',
+    colormap = {'GND': 'black', 'GN': 'black', 'CL': 'green', 'CR': 'blue',
                 'DE': 'orange', 'LVL': 'purple', 'NA': 'red'}
 
     # Number of files to open in one go

--- a/OS_Funcs.py
+++ b/OS_Funcs.py
@@ -351,7 +351,7 @@ def proc_fl(flight, check_rwys, odirs, colormap, do_save, verbose):
     # Correct barometric altitudes
     t_alt = fd['alts']
     l_time = fd['strt'] + (fd['dura'] / 2)
-    l_time = pd.Timestamp(l_time, tz='UTC')
+    l_time = pd.Timestamp(l_time)
     bmet, tdiff = find_closest_metar(l_time, metars)
     if (bmet is not None):
         t_alt = correct_baro(t_alt, bmet.temp, bmet.pres)
@@ -363,16 +363,17 @@ def proc_fl(flight, check_rwys, odirs, colormap, do_save, verbose):
     # Now the actual go-around check
     ga_flag, gapt = check_ga(fd, True)
 
+    if (ga_flag):
+        odir_pl = odirs[1]
+        odir_np = odirs[3]
+    else:
+        odir_pl = odirs[0]
+        odir_np = odirs[2]
+
     # Make some plots if required, this needs a spline to smooth output
     if do_save:
         spldict = create_spline(fd, bpos=None)
         # Choose output directory based upon go-around flag
-        if (ga_flag):
-            odir_pl = odirs[1]
-            odir_np = odirs[3]
-        else:
-            odir_pl = odirs[0]
-            odir_np = odirs[2]
         OSO.do_plots(fd,
                      spldict,
                      colormap,
@@ -381,8 +382,7 @@ def proc_fl(flight, check_rwys, odirs, colormap, do_save, verbose):
                      bpos=None)
     if (ga_flag):
         ga_time = pd.Timestamp(fd['strt'] +
-                               pd.Timedelta(seconds=fd['time'][gapt]),
-                               tz='UTC')
+                               pd.Timedelta(seconds=fd['time'][gapt]))
     else:
         gapt = 0
         ga_time = fd['strt']
@@ -679,6 +679,7 @@ def do_labels(fd):
     try:
         labels = flph.fuzzylabels(fd['time'], fd['alts'],
                                   fd['spds'], fd['rocs'], twindow=15)
+        labels = np.array(labels)
     except Exception as e:
         print("Error creating spline", e, fd['call'])
         quit()


### PR DESCRIPTION
- pd.Timedelta does not like to be initialized with `tz` argument,
failing with "Cannot pass a datetime or Timestamp with tzinfo with the
tz parameter. Use tz_convert instead."  My understanding is that since
all timezones are UTC throughout, it should be safe to drop this
everywhere.

- flph.fuzzylabels returns a list for me, and so I explicitly convert
it to an np.array before applying fancy indexing with `labels[pts] =
'GND'`.  Before, this would error with "list indices must be integers
or slices, not tuple".

- The existing glob pattern did not seem to work for the new way of
saving pickles into subdirectories of `outdir`.  Instead I'm now
applying to separate glob patterns that will pick up pkl files from
the `INDATA/` directory and its subdirectories.

- I'm creating the output directories for plots and data if they do
not exist already.

- The plotting functions mysteriously saw a `GN` label.  I'm really
not sure if this is the right thing to do here, but I simply assumed
that this was the same as `GND` and added another entry to the
colormap accordingly.  This may be really a symptom of a bug that
should be fixed in another place.